### PR TITLE
Add \r for rstrip

### DIFF
--- a/jicson/jicson.py
+++ b/jicson/jicson.py
@@ -62,7 +62,7 @@ def parseChild(json, fileObject):
         if not line: 
             return json
 
-        line = line.rstrip('\n')
+        line = line.rstrip('\n\r')
 
         separator = line.find(":")
         


### PR DESCRIPTION
Helps in Windows systems... just happend to use the lib here and found a lot of \r in the keys.